### PR TITLE
Bash requires "-fPIE" to be passed, add "package set ccflags "-fPIE"".

### DIFF
--- a/formula/bash.sh
+++ b/formula/bash.sh
@@ -7,7 +7,7 @@ package set version "5.0.18"
 package set license "GPL-3.0-or-later"
 package set bsystem "configure"
 package set dep.pkg "readline ncurses"
-package set cflags  "-fPIE"
+package set ccflags "-fPIE"
 
 build() {
     configure \

--- a/formula/bash.sh
+++ b/formula/bash.sh
@@ -7,6 +7,7 @@ package set version "5.0.18"
 package set license "GPL-3.0-or-later"
 package set bsystem "configure"
 package set dep.pkg "readline ncurses"
+package set cflags  "-fPIE"
 
 build() {
     configure \


### PR DESCRIPTION
If you wish you can update bash to 5.1 or something additional
I didn't got down as to why it wants to use this linker "/lib/ld-linux-aarch64.so.1"